### PR TITLE
Changing request header to get English movie titles

### DIFF
--- a/moviepicker/main.py
+++ b/moviepicker/main.py
@@ -7,7 +7,9 @@ from bs4 import BeautifulSoup
 URL = 'http://www.imdb.com/chart/top'
 
 def main():
-    response = requests.get(URL)
+    # getting English titles by setting accept-language header
+    headers = {"Accept-Language": "en-US,en;q=0.5"}
+    response = requests.get(URL, headers=headers)
 
     soup = BeautifulSoup(response.text, 'html.parser')
     #soup = BeautifulSoup(response.text, 'lxml') # faster


### PR DESCRIPTION
By changing the accept-language header for the initial request we can make sure to always get the English title for movies, not the translation for the current location of the user

Before (user based in Germany):
``` 'Die Verurteilten', 'Der Pate', 'Der Pate 2', 'The Dark Knight', 'Die zwölf Geschworenen' ```

After:
``` 'The Shawshank Redemption', 'The Godfather', 'The Godfather: Part II', 'The Dark Knight', '12 Angry Men' ```